### PR TITLE
fix semantic tokens

### DIFF
--- a/open_musiclm/clap_quantized.py
+++ b/open_musiclm/clap_quantized.py
@@ -10,7 +10,7 @@ from transformers import RobertaTokenizer
 from vector_quantize_pytorch import ResidualVQ
 
 from .laion_clap import CLAP_Module
-from .utils import exists, beartype_jit
+from .utils import exists, beartype_jit, int16_to_float32, float32_to_int16
 
 
 @beartype_jit

--- a/open_musiclm/config.py
+++ b/open_musiclm/config.py
@@ -31,7 +31,8 @@ class ClapRVQConfig:
 @dataclass
 class HubertKmeansConfig:
     model_name: str
-    normalize_embeds: bool
+    normalize_input: bool = True
+    normalize_embeds: bool = True
     embed_layer: int = 7
     target_sample_hz: int = 16000
     seq_len_multiple_of: int = 320

--- a/open_musiclm/data.py
+++ b/open_musiclm/data.py
@@ -16,9 +16,7 @@ from torch.nn.utils.rnn import pad_sequence
 from torch.utils.data import DataLoader, Dataset, IterableDataset
 from torchaudio.functional import resample
 
-from .utils import (beartype_jit, curtail_to_multiple, default,
-                    float32_to_int16, int16_to_float32,
-                    zero_mean_unit_var_norm)
+from .utils import (beartype_jit, curtail_to_multiple, default)
 
 # helper functions
 
@@ -68,7 +66,6 @@ class SoundDataset(Dataset):
         folder,
         exts = ['flac', 'wav', 'mp3'],
         max_length_seconds: Optional[Union[FloatOrInt, Tuple[Optional[FloatOrInt], ...]]] = 1,
-        normalize: Union[bool, Tuple[bool, ...]] = False,
         target_sample_hz: OptionalIntOrTupleInt = None,
         seq_len_multiple_of: OptionalIntOrTupleInt = None,
         ignore_files: Optional[List[str]] = None,
@@ -104,12 +101,10 @@ class SoundDataset(Dataset):
         self.max_length_seconds = cast_tuple(max_length_seconds, num_outputs)
         self.max_length = tuple([int(s * hz) if exists(s) else None for s, hz in zip(self.max_length_seconds, self.target_sample_hz)])
 
-        self.normalize = cast_tuple(normalize, num_outputs)
-
         self.seq_len_multiple_of = cast_tuple(seq_len_multiple_of, num_outputs)
 
         assert len(self.max_length) == len(self.max_length_seconds) == len(
-            self.target_sample_hz) == len(self.seq_len_multiple_of) == len(self.normalize)
+            self.target_sample_hz) == len(self.seq_len_multiple_of)
 
     def __len__(self):
         return len(self.files)
@@ -134,10 +129,8 @@ class SoundDataset(Dataset):
 
         # recursively crop the audio at random in the order of longest to shortest max_length_seconds, padding when necessary.
         # e.g. if max_length_seconds = (10, 4), pick a 10 second crop from the original, then pick a 4 second crop from the 10 second crop
-        # also use normalized data when specified
 
         temp_data = data
-        temp_data_normalized = zero_mean_unit_var_norm(data)
 
         num_outputs = len(self.target_sample_hz)
         data = [None for _ in range(num_outputs)]
@@ -157,17 +150,14 @@ class SoundDataset(Dataset):
                     start = torch.randint(0, max_start, (1, )) if self.random_crop else 0
 
                     temp_data = temp_data[:, start:start + target_length]
-                    temp_data_normalized = temp_data_normalized[:, start:start + target_length]
                 else:
                     if pad_to_target_length:
                         temp_data = F.pad(temp_data, (0, target_length - audio_length), 'constant')
-                        temp_data_normalized = F.pad(temp_data_normalized, (0, target_length - audio_length), 'constant')
 
-            data[unsorted_i] = temp_data_normalized if self.normalize[unsorted_i] else temp_data
+            data[unsorted_i] = temp_data
+
         # resample if target_sample_hz is not None in the tuple
         data_tuple = tuple((resample(d, sample_hz, target_sample_hz) if exists(target_sample_hz) else d) for d, target_sample_hz in zip(data, self.target_sample_hz))
-        # quantize non-normalized audio to a valid waveform
-        data_tuple = tuple(d if self.normalize[i] else int16_to_float32(float32_to_int16(d)) for i, d in enumerate(data_tuple))
 
         output = []
 

--- a/open_musiclm/hf_hubert_kmeans.py
+++ b/open_musiclm/hf_hubert_kmeans.py
@@ -30,6 +30,7 @@ class HfHubertWithKmeans(nn.Module):
         embed_layer: int=7,
         target_sample_hz=16000,
         seq_len_multiple_of=int(16000 / 50),
+        normalize_input=True,
         normalize_embeds=True,
         codebook_size: int=1024,
         output_hz: int=50
@@ -44,6 +45,7 @@ class HfHubertWithKmeans(nn.Module):
         if exists(kmeans):
             assert self.codebook_size == kmeans.n_clusters, "codebook_size must match kmeans.n_clusters"
 
+        self.normalize_input = normalize_input
         self.normalize_embeds = normalize_embeds
 
         self.embed_layer = embed_layer
@@ -68,6 +70,9 @@ class HfHubertWithKmeans(nn.Module):
 
         if exists(self.seq_len_multiple_of):
             wav_input = curtail_to_multiple(wav_input, self.seq_len_multiple_of)
+
+        if self.normalize_input:
+            wav_input = zero_mean_unit_var_norm(wav_input)
 
         hubert_args = {
             'input_values': wav_input,

--- a/open_musiclm/open_musiclm.py
+++ b/open_musiclm/open_musiclm.py
@@ -888,13 +888,11 @@ class MusicLM(nn.Module):
                 prime_wave,
                 prime_wave_sample_hz,
                 self.wav2vec.target_sample_hz,
-                normalize=True,
                 target_length_seconds=semantic_window_seconds)
             prime_wave_encodec = prepare_audio(
                 prime_wave,
                 prime_wave_sample_hz,
                 self.neural_codec.sample_rate,
-                normalize=False,
                 target_length_seconds=semantic_window_seconds)
 
             condition_semantic_token_ids = get_or_compute_semantic_token_ids(None, prime_wave_wav2vec, self.wav2vec)
@@ -1048,7 +1046,6 @@ class MusicLM(nn.Module):
             text_latents = repeat(text_latents, 'b d -> (repeat b) d', repeat=num_samples)
 
             clap_input = resample(samples, self.neural_codec.sample_rate, self.clap.sample_rate)
-            clap_input = int16_to_float32(float32_to_int16(clap_input))
             audio_latents = self.clap(audio_input=clap_input, return_embedding=True)
 
             sim = F.cosine_similarity(text_latents, audio_latents, dim=-1)

--- a/open_musiclm/preprocess.py
+++ b/open_musiclm/preprocess.py
@@ -139,8 +139,6 @@ class DataPreprocessor(nn.Module):
 
         target_sample_hz = (audio_conditioner.sample_rate, wav2vec.target_sample_hz, neural_codec.sample_rate)
 
-        normalize = (False, True, False)
-
         seq_len_multiple_of = (None, wav2vec.seq_len_multiple_of, None)
 
         data_max_length_seconds = (max_audio_length_seconds, max_audio_length_seconds, max_audio_length_seconds)
@@ -152,7 +150,6 @@ class DataPreprocessor(nn.Module):
             pad_to_seconds=self.semantic_audio_length_seconds,
             max_length_seconds=data_max_length_seconds,
             random_crop=random_crop,
-            normalize=normalize,
             target_sample_hz=target_sample_hz,
             seq_len_multiple_of=seq_len_multiple_of,
             ignore_load_errors=ignore_load_errors,

--- a/open_musiclm/trainer.py
+++ b/open_musiclm/trainer.py
@@ -181,7 +181,6 @@ class SingleStageTrainer(nn.Module):
             else:
                 self.ds_fields = ('raw_wave_for_clap', 'raw_wave_for_semantic')
                 target_sample_hz = (audio_conditioner.sample_rate, wav2vec.target_sample_hz)
-                normalize = (False, True)
                 seq_len_multiple_of = wav2vec.seq_len_multiple_of
         elif stage == 'coarse':
             assert self.use_preprocessed_data or (exists(wav2vec) and exists(audio_conditioner) and exists(neural_codec))
@@ -197,7 +196,6 @@ class SingleStageTrainer(nn.Module):
             else:
                 self.ds_fields = ('raw_wave_for_clap', 'raw_wave_for_semantic', 'raw_wave_for_acoustic')
                 target_sample_hz = (audio_conditioner.sample_rate, wav2vec.target_sample_hz, neural_codec.sample_rate)
-                normalize = (False, True, False)
                 seq_len_multiple_of = wav2vec.seq_len_multiple_of
         elif stage == 'fine':
             assert self.use_preprocessed_data or (exists(audio_conditioner) and exists(neural_codec))
@@ -212,7 +210,6 @@ class SingleStageTrainer(nn.Module):
             else:
                 self.ds_fields = ('raw_wave_for_clap', 'raw_wave_for_acoustic')
                 target_sample_hz = (audio_conditioner.sample_rate, neural_codec.sample_rate)
-                normalize = (False, False)
                 seq_len_multiple_of = None
         else:
             raise ValueError(f'invalid stage: {stage}')
@@ -260,7 +257,6 @@ class SingleStageTrainer(nn.Module):
                 self.ds = SoundDataset(
                     folder,
                     max_length_seconds=data_max_length_seconds,
-                    normalize=normalize,
                     target_sample_hz=target_sample_hz,
                     seq_len_multiple_of=seq_len_multiple_of,
                     ignore_files=default(ignore_files, []),
@@ -781,7 +777,6 @@ class HfHubertKmeansTrainer(nn.Module):
             self.ds = SoundDataset(
                 folder,
                 max_length_seconds=data_max_length_seconds,
-                normalize=True,
                 target_sample_hz=hubert_kmeans.target_sample_hz,
                 seq_len_multiple_of=hubert_kmeans.seq_len_multiple_of,
                 ignore_files=default(ignore_files, []),

--- a/open_musiclm/utils.py
+++ b/open_musiclm/utils.py
@@ -154,15 +154,12 @@ def float32_to_int16(x):
 def zero_mean_unit_var_norm(x):
     return (x - x.mean(dim=-1, keepdim=True)) / torch.sqrt(x.var(dim=-1, keepdim=True) + 1e-7)
 
-def prepare_audio(data, sample_hz, target_sample_hz, normalize=True, target_length_seconds=None):
+def prepare_audio(data, sample_hz, target_sample_hz, target_length_seconds=None):
     if data.shape[0] > 1:
         data = torch.mean(data, dim=0).unsqueeze(0)
-    if normalize:
-        data = zero_mean_unit_var_norm(data)
     if exists(target_length_seconds) and data.shape[1] > target_length_seconds * sample_hz:
         data = data[: , :int(target_length_seconds * sample_hz)]
     audio_for_wav2vec = resample(data, sample_hz, target_sample_hz)
-    audio_for_wav2vec = int16_to_float32(float32_to_int16(audio_for_wav2vec))
     return audio_for_wav2vec
 
 # helper for saving config

--- a/scripts/infer_coarse.py
+++ b/scripts/infer_coarse.py
@@ -94,15 +94,10 @@ if __name__ == '__main__':
             data = torch.mean(data, dim=0).unsqueeze(0)
 
         target_length = int(4 * sample_hz)
-        normalized_data = zero_mean_unit_var_norm(data)
 
         data = data[:, :target_length]
-        normalized_data = normalized_data[: , :target_length]
         audio_for_clap = resample(data, sample_hz, clap.sample_rate)
-        audio_for_wav2vec = resample(normalized_data, sample_hz, wav2vec.target_sample_hz)
-
-        audio_for_clap = int16_to_float32(float32_to_int16(audio_for_clap))
-        audio_for_wav2vec = int16_to_float32(float32_to_int16(audio_for_wav2vec))
+        audio_for_wav2vec = resample(data, sample_hz, wav2vec.target_sample_hz)
 
         audios_for_clap.append(audio_for_clap)
         audios_for_wav2vec.append(audio_for_wav2vec)

--- a/scripts/test/test_dataloader.py
+++ b/scripts/test/test_dataloader.py
@@ -21,7 +21,6 @@ folder = './data/fma_large/000'
 dataset = SoundDataset(
     folder,
     max_length_seconds=(1, 5),
-    normalize=(True, False),
     target_sample_hz=(16000, 24000),
     seq_len_multiple_of=None,
     ignore_load_errors=True
@@ -42,7 +41,6 @@ for i in range(test_steps):
 dataset = SoundDatasetForPreprocessing(
     folder,
     max_length_seconds=(None, 1),
-    normalize=(True, False),
     target_sample_hz=(16000, 24000),
     seq_len_multiple_of=None,
     ignore_load_errors=True


### PR DESCRIPTION
- move normalization into the hubert model. brings back part of 77ee0f4. (realized the approach discussed in #7 is not a good idea)
- simplify data processing and remove redundant operations
- changes to the way semantic tokens are computed in preprocessing